### PR TITLE
Add test for __mulsi3

### DIFF
--- a/mulsi3/Makefile
+++ b/mulsi3/Makefile
@@ -1,0 +1,6 @@
+firmware.elf: main.c mulsi3.S Makefile
+	avr-gcc -o firmware.elf main.c mulsi3.S -Os -mmcu=atmega1284p
+
+.PHONY: test
+test: firmware.elf
+	simavr -m atmega1284p -f 20000000 ./firmware.elf

--- a/mulsi3/main.c
+++ b/mulsi3/main.c
@@ -1,0 +1,47 @@
+#include <avr/io.h>
+#include <stdio.h>
+#include <stdint.h>
+
+static int uart_putchar(char c, FILE *stream) {
+	UDR0 = c; // good enough for simavr
+}
+
+static FILE mystdout = FDEV_SETUP_STREAM(uart_putchar, NULL, _FDEV_SETUP_WRITE);
+
+// Source: https://en.wikipedia.org/wiki/Xorshift
+static uint32_t xorshift32_state = 1;
+uint32_t xorshift32(void)
+{
+	uint32_t x = xorshift32_state;
+	x ^= x << 13;
+	x ^= x >> 17;
+	x ^= x << 5;
+	xorshift32_state = x;
+	return x;
+}
+
+long test_mulsi3(long a, long b);
+
+int main(void) {
+	// needed for printf
+	stdout = &mystdout;
+
+	// Iterate continuously, looking for mismatches.
+	unsigned long n = 0;
+	while (1) {
+		long a = xorshift32();
+		long b = xorshift32();
+
+		if ((n % (1ul << 20)) == 0) {
+			printf("%8lu: %ld * %ld\r\n", n, a, b);
+		}
+		n++;
+
+		long actual = test_mulsi3(a, b);
+		long expected = a * b;
+		if (expected != actual) {
+			printf("invalid result: %l * %l = %l (expected %l)\n", a, b, actual, expected);
+		}
+	}
+	return 0;
+}

--- a/mulsi3/mulsi3.S
+++ b/mulsi3/mulsi3.S
@@ -1,0 +1,90 @@
+//===------------ mulsi3.S - int32 multiplication -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// The assembly implementation corresponds to the following C code, that is
+// tested with over 10000000000 (1e10) random combinations of A and B:
+//
+//   uint32_t test_mulsi3(uint32_t A, uint32_t B) {
+//     uint32_t S = 0;
+//     do {
+//       if (A & 1)
+//         S += B;
+//       A >>= 1;
+//       B <<= 1;
+//     } while (A != 0);
+//     return S;
+//   }
+//
+// __mulsi3 has a special ABI: the calling convention is as usual except that
+// only R26, R27, Rtmp and SREG are clobbered.
+//
+//===----------------------------------------------------------------------===//
+
+    .text
+    .align 2
+
+#if !defined(__AVR_TINY__) // TODO: add support for avrtiny
+
+    .set __tmp_reg__, 0
+    .set __zero_reg__, 1
+
+    .globl test_mulsi3
+    .type  test_mulsi3, @function
+
+; parameter A is stored in r22-r25
+; parameter B is stored in r18-r21
+; result is stored in r22-r25
+test_mulsi3:
+    ; S = 0;
+    clr   r26
+    clr   r27
+    clr   __tmp_reg__
+    ;clr   __zero_reg__ ; not needed (already zero)
+
+1: ; loop
+    ; if (A & 1)
+    ;   S += B;
+    sbrs r22, 0
+    rjmp 2f
+    add r26,          r18
+    adc r27,          r19
+    adc __tmp_reg__,  r20
+    adc __zero_reg__, r21
+
+2:
+    ; A >>= 1;
+    lsr r25
+    ror r24
+    ror r23
+    ror r22
+
+    ; B <<= 1;
+    lsl r18
+    rol r19
+    rol r20
+    rol r21
+
+    ; do { ... } while (A != 0);
+    subi r22, 0
+    sbci r23, 0
+    sbci r24, 0
+    sbci r25, 0
+    brne 1b
+
+3:
+    ; Return the result via r22-r25.
+    mov   r22, r26
+    mov   r23, r27
+    mov   r24, __tmp_reg__
+    mov   r25, __zero_reg__
+    ; Restore __zero_reg__ to 0.
+    clr   __zero_reg__
+    ; Return to parent.
+    ret
+
+#endif // defined(__AVR_TINY__)


### PR DESCRIPTION
This test is a bit different from the others: I've written it in such a way that it should be run in simavr (instead of on real AVR hardware). This makes it much easier to test the code without fiddling with hardware.

To run this test locally, simply run:

    make test

I ran this test for over 100000000 (1e8) pairs of numbers without any mismatches.